### PR TITLE
change log level for protocol headers to debug

### DIFF
--- a/be/src/Unic.UrlMapper2/code/Services/RedirectSearchDataService.cs
+++ b/be/src/Unic.UrlMapper2/code/Services/RedirectSearchDataService.cs
@@ -58,7 +58,7 @@
                     return value;
                 }
 
-                this.logger.Warn($"Header {headerName} could not be found in the current request. Falling back to current request scheme", this);
+                this.logger.Debug($"Header {headerName} could not be found in the current request. Falling back to current request scheme", this);
             }
 
             // ... otherwise use the protocol provided from the HttpContext
@@ -78,7 +78,7 @@
                 if (!string.IsNullOrWhiteSpace(value)) return value;
             }
 
-            this.logger.Warn($"Header {headerName} could not be found in the current JSS request. Falling back to current request scheme", this);
+            this.logger.Debug($"Header {headerName} could not be found in the current JSS request. Falling back to current request scheme", this);
 
             // ... otherwise use the protocol provided from the HttpContext
             return httpContext.Request.Url?.Scheme;


### PR DESCRIPTION
in non proxied environments logs are polluted on every request because x-forwarded-proto header is not found:
![image](https://user-images.githubusercontent.com/17006929/77251877-2ceb7280-6c51-11ea-81a9-786e0beccc33.png)
