### PR TITLE
Preserve casing of capture groups

### DIFF
--- a/be/GitVersion.yml
+++ b/be/GitVersion.yml
@@ -7,21 +7,21 @@ minor-version-bump-message: '\+semver:\s?(breaking|major)'
 patch-version-bump-message: '\+semver:\s?(feature|minor)'
 no-bump-message: '\+semver:\s?(none|skip)'
 branches:
-main:
-tag: ''
-increment: Patch
-prevent-increment-of-merged-branch-version: true
-regex: ^main$
-is-release-branch: true
-is-mainline: true
-feature:
-tag: ft
-tag-number-pattern: '[/-](?<number>\d+)[-/]'
-increment: Inherit
-source-branches:
-- main
-is-mainline: false
-pull-request:
-tag: pull
-tag-number-pattern: '[/-](?<number>\d+)[-/]'
+  main:
+    tag: ''
+    increment: Patch
+    prevent-increment-of-merged-branch-version: true
+    regex: ^main$
+    is-release-branch: true
+    is-mainline: true
+  feature:
+    tag: ft
+    tag-number-pattern: '[/-](?<number>\d+)[-/]'
+    increment: Inherit
+    source-branches:
+    - main
+    is-mainline: false
+  pull-request:
+    tag: pull
+    tag-number-pattern: '[/-](?<number>\d+)[-/]'
 merge-message-formats: {}

--- a/be/GitVersion.yml
+++ b/be/GitVersion.yml
@@ -1,4 +1,27 @@
-mode: ContinuousDelivery
-branches: {}
-ignore:
-  sha: []
+assembly-versioning-scheme: MajorMinorPatch
+mode: mainline
+continuous-delivery-fallback-tag: ''
+tag-prefix: '[vV]'
+major-version-bump-message: '\+semver:\s?(dotnotuse)'
+minor-version-bump-message: '\+semver:\s?(breaking|major)'
+patch-version-bump-message: '\+semver:\s?(feature|minor)'
+no-bump-message: '\+semver:\s?(none|skip)'
+branches:
+main:
+tag: ''
+increment: Patch
+prevent-increment-of-merged-branch-version: true
+regex: ^main$
+is-release-branch: true
+is-mainline: true
+feature:
+tag: ft
+tag-number-pattern: '[/-](?<number>\d+)[-/]'
+increment: Inherit
+source-branches:
+- main
+is-mainline: false
+pull-request:
+tag: pull
+tag-number-pattern: '[/-](?<number>\d+)[-/]'
+merge-message-formats: {}

--- a/be/src/Unic.UrlMapper2/code/Models/RedirectSearchData.cs
+++ b/be/src/Unic.UrlMapper2/code/Models/RedirectSearchData.cs
@@ -4,6 +4,8 @@
     {
         public string SourceTerm { get; set;  }
 
+        public string SourceTermOriginal { get; set;  }
+
         public string Language { get; set;  }
 
         public string SiteName { get; set;  }
@@ -12,11 +14,13 @@
 
         public RedirectSearchData(
             string sourceTerm,
+            string sourceTermOriginal,
             string language,
             string siteName,
             string sourceProtocol)
         {
             this.SourceTerm = sourceTerm;
+            this.SourceTermOriginal = sourceTermOriginal;
             this.Language = language;
             this.SiteName = siteName;
             this.SourceProtocol = sourceProtocol;

--- a/be/src/Unic.UrlMapper2/code/Models/RedirectSearchData.cs
+++ b/be/src/Unic.UrlMapper2/code/Models/RedirectSearchData.cs
@@ -2,13 +2,16 @@
 {
     public class RedirectSearchData
     {
-        public string SourceTerm { get; set;  }
+        public string SourceTerm { get; set; }
 
-        public string SourceTermOriginal { get; set;  }
+        /// <summary>
+        /// Source Term with the original casing
+        /// </summary>
+        public string SourceTermOriginal { get; set; }
 
-        public string Language { get; set;  }
+        public string Language { get; set; }
 
-        public string SiteName { get; set;  }
+        public string SiteName { get; set; }
 
         public string SourceProtocol { get; set; }
 

--- a/be/src/Unic.UrlMapper2/code/Properties/AssemblyInfo.cs
+++ b/be/src/Unic.UrlMapper2/code/Properties/AssemblyInfo.cs
@@ -30,5 +30,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.1.3.0")]
-[assembly: AssemblyFileVersion("1.1.3.0")]
+[assembly: AssemblyVersion("1.2.0.0")]
+[assembly: AssemblyFileVersion("1.2.0.0")]

--- a/be/src/Unic.UrlMapper2/code/Services/ISanitizer.cs
+++ b/be/src/Unic.UrlMapper2/code/Services/ISanitizer.cs
@@ -6,7 +6,7 @@
     {
         void SanitizeRedirectSearchData(RedirectSearchData redirectSearchData);
 
-        string SanitizeTerm(string value, bool withToLower = true);
+        string SanitizeTerm(string value, bool convertToLower = true);
 
         string SanitizeSiteName(string value);
 

--- a/be/src/Unic.UrlMapper2/code/Services/ISanitizer.cs
+++ b/be/src/Unic.UrlMapper2/code/Services/ISanitizer.cs
@@ -6,7 +6,7 @@
     {
         void SanitizeRedirectSearchData(RedirectSearchData redirectSearchData);
 
-        string SanitizeTerm(string value);
+        string SanitizeTerm(string value, bool withToLower = true);
 
         string SanitizeSiteName(string value);
 

--- a/be/src/Unic.UrlMapper2/code/Services/RedirectSearchDataService.cs
+++ b/be/src/Unic.UrlMapper2/code/Services/RedirectSearchDataService.cs
@@ -25,13 +25,17 @@
             this.logger = logger;
         }
 
-        public virtual RedirectSearchData GetDefaultRedirectSearchData(HttpRequestArgs args) =>
-            new RedirectSearchData(
-                sourceTerm: this.GetSourceTermForDefaultRedirectSearchData(args),
-                sourceTermOriginal: this.GetSourceTermForDefaultRedirectSearchData(args),
+        public virtual RedirectSearchData GetDefaultRedirectSearchData(HttpRequestArgs args)
+        {
+            var sourceTerm = this.GetSourceTermForDefaultRedirectSearchData(args);
+
+            return new RedirectSearchData(
+                sourceTerm: sourceTerm,
+                sourceTermOriginal: sourceTerm,
                 language: this.context.Language?.Name,
                 siteName: this.context.Site?.Name?.ToLower(),
                 sourceProtocol: this.GetSourceProtocolForDefaultRedirectSearchData(args));
+        }
 
         protected virtual string GetSourceTermForDefaultRedirectSearchData(HttpRequestArgs args)
         {

--- a/be/src/Unic.UrlMapper2/code/Services/RedirectSearchDataService.cs
+++ b/be/src/Unic.UrlMapper2/code/Services/RedirectSearchDataService.cs
@@ -28,6 +28,7 @@
         public virtual RedirectSearchData GetDefaultRedirectSearchData(HttpRequestArgs args) =>
             new RedirectSearchData(
                 sourceTerm: this.GetSourceTermForDefaultRedirectSearchData(args),
+                sourceTermOriginal: this.GetSourceTermForDefaultRedirectSearchData(args),
                 language: this.context.Language?.Name,
                 siteName: this.context.Site?.Name?.ToLower(),
                 sourceProtocol: this.GetSourceProtocolForDefaultRedirectSearchData(args));
@@ -47,6 +48,7 @@
         public virtual RedirectSearchData GetJssRedirectSearchData(HttpContextBase httpContext) =>
             new RedirectSearchData(
                 sourceTerm: this.GetSourceTermForJssRedirectSearchData(httpContext),
+                sourceTermOriginal: this.GetSourceTermForJssRedirectSearchData(httpContext),
                 language: this.context.Language?.Name,
                 siteName: this.context.Site?.Name,
                 sourceProtocol: this.GetSourceProtocolForJssRedirectSearchData(httpContext));

--- a/be/src/Unic.UrlMapper2/code/Services/RedirectSearchDataService.cs
+++ b/be/src/Unic.UrlMapper2/code/Services/RedirectSearchDataService.cs
@@ -49,13 +49,17 @@
             return startIndex < 0 ? default : args.RequestUrl.PathAndQuery.Substring(startIndex);
         }
 
-        public virtual RedirectSearchData GetJssRedirectSearchData(HttpContextBase httpContext) =>
-            new RedirectSearchData(
-                sourceTerm: this.GetSourceTermForJssRedirectSearchData(httpContext),
-                sourceTermOriginal: this.GetSourceTermForJssRedirectSearchData(httpContext),
+        public virtual RedirectSearchData GetJssRedirectSearchData(HttpContextBase httpContext)
+        {
+            var sourceTerm = this.GetSourceTermForJssRedirectSearchData(httpContext);
+
+            return new RedirectSearchData(
+                sourceTerm: sourceTerm,
+                sourceTermOriginal: sourceTerm,
                 language: this.context.Language?.Name,
                 siteName: this.context.Site?.Name,
                 sourceProtocol: this.GetSourceProtocolForJssRedirectSearchData(httpContext));
+        }
 
         protected virtual string GetSourceProtocolForDefaultRedirectSearchData(HttpRequestArgs args)
         {

--- a/be/src/Unic.UrlMapper2/code/Services/RedirectionService.cs
+++ b/be/src/Unic.UrlMapper2/code/Services/RedirectionService.cs
@@ -51,16 +51,16 @@
             var redirect = this.FilterRedirects(redirects, redirectSearchData);
             if (redirect is null) return;
 
-            var additionalTargetData = this.GetAdditionalTargetUrlData(redirectSearchData.SourceTermOriginal, redirect);
+            var additionalTargetData = this.GetAdditionalTargetUrlData(redirectSearchData, redirect);
 
             this.PerformRedirect(redirect, httpContext, additionalTargetData);
         }
 
-        protected virtual string GetAdditionalTargetUrlData(string sourceTerm, Redirect redirect)
+        protected virtual string GetAdditionalTargetUrlData(RedirectSearchData redirectSearchData, Redirect redirect)
         {
             if (!redirect.RegexEnabled) return default;
 
-            var match = Regex.Match(sourceTerm, redirect.Term, RegexOptions.IgnoreCase);
+            var match = Regex.Match(redirectSearchData.SourceTermOriginal, redirect.Term, RegexOptions.IgnoreCase);
             if (match.Groups.Count <= 1) return default;
 
             string additionalTargetData = null;

--- a/be/src/Unic.UrlMapper2/code/Services/RedirectionService.cs
+++ b/be/src/Unic.UrlMapper2/code/Services/RedirectionService.cs
@@ -51,16 +51,16 @@
             var redirect = this.FilterRedirects(redirects, redirectSearchData);
             if (redirect is null) return;
 
-            var additionalTargetData = this.GetAdditionalTargetUrlData(redirectSearchData, redirect);
+            var additionalTargetData = this.GetAdditionalTargetUrlData(redirectSearchData.SourceTermOriginal, redirect);
 
             this.PerformRedirect(redirect, httpContext, additionalTargetData);
         }
 
-        protected virtual string GetAdditionalTargetUrlData(RedirectSearchData redirectSearchData, Redirect redirect)
+        protected virtual string GetAdditionalTargetUrlData(string sourceTerm, Redirect redirect)
         {
             if (!redirect.RegexEnabled) return default;
 
-            var match = Regex.Match(redirectSearchData.SourceTerm, redirect.Term);
+            var match = Regex.Match(sourceTerm, redirect.Term, RegexOptions.IgnoreCase);
             if (match.Groups.Count <= 1) return default;
 
             string additionalTargetData = null;

--- a/be/src/Unic.UrlMapper2/code/Services/Sanitizer.cs
+++ b/be/src/Unic.UrlMapper2/code/Services/Sanitizer.cs
@@ -13,7 +13,7 @@
             redirectSearchData.SourceProtocol = this.SanitizeProtocol(redirectSearchData.SourceProtocol);
         }
 
-        public virtual string SanitizeTerm(string value, bool withToLower = true)
+        public virtual string SanitizeTerm(string value, bool convertToLower = true)
         {
             if (string.IsNullOrWhiteSpace(value)) return default;
 
@@ -22,7 +22,7 @@
             value = StringUtil.RemovePrefix('/', value);
             value = StringUtil.RemovePostfix('/', value);
 
-            return withToLower ? value.ToLower() : value;
+            return convertToLower ? value.ToLower() : value;
         }
 
         public virtual string SanitizeSiteName(string value) => value?.Trim().ToLower();

--- a/be/src/Unic.UrlMapper2/code/Services/Sanitizer.cs
+++ b/be/src/Unic.UrlMapper2/code/Services/Sanitizer.cs
@@ -7,13 +7,13 @@
     {
         public virtual void SanitizeRedirectSearchData(RedirectSearchData redirectSearchData)
         {
-            redirectSearchData.SourceTerm = this.SanitizeTerm(redirectSearchData.SourceTerm)?.ToLower();
-            redirectSearchData.SourceTermOriginal = this.SanitizeTerm(redirectSearchData.SourceTermOriginal);
+            redirectSearchData.SourceTerm = this.SanitizeTerm(redirectSearchData.SourceTerm);
+            redirectSearchData.SourceTermOriginal = this.SanitizeTerm(redirectSearchData.SourceTermOriginal, false);
             redirectSearchData.SiteName = this.SanitizeSiteName(redirectSearchData.SiteName);
             redirectSearchData.SourceProtocol = this.SanitizeProtocol(redirectSearchData.SourceProtocol);
         }
 
-        public virtual string SanitizeTerm(string value)
+        public virtual string SanitizeTerm(string value, bool withToLower = true)
         {
             if (string.IsNullOrWhiteSpace(value)) return default;
 
@@ -22,7 +22,7 @@
             value = StringUtil.RemovePrefix('/', value);
             value = StringUtil.RemovePostfix('/', value);
 
-            return value;
+            return withToLower ? value.ToLower() : value;
         }
 
         public virtual string SanitizeSiteName(string value) => value?.Trim().ToLower();

--- a/be/src/Unic.UrlMapper2/code/Services/Sanitizer.cs
+++ b/be/src/Unic.UrlMapper2/code/Services/Sanitizer.cs
@@ -7,7 +7,8 @@
     {
         public virtual void SanitizeRedirectSearchData(RedirectSearchData redirectSearchData)
         {
-            redirectSearchData.SourceTerm = this.SanitizeTerm(redirectSearchData.SourceTerm);
+            redirectSearchData.SourceTerm = this.SanitizeTerm(redirectSearchData.SourceTerm)?.ToLower();
+            redirectSearchData.SourceTermOriginal = this.SanitizeTerm(redirectSearchData.SourceTermOriginal);
             redirectSearchData.SiteName = this.SanitizeSiteName(redirectSearchData.SiteName);
             redirectSearchData.SourceProtocol = this.SanitizeProtocol(redirectSearchData.SourceProtocol);
         }
@@ -16,7 +17,7 @@
         {
             if (string.IsNullOrWhiteSpace(value)) return default;
 
-            value = value.Trim().ToLower();
+            value = value.Trim();
 
             value = StringUtil.RemovePrefix('/', value);
             value = StringUtil.RemovePostfix('/', value);

--- a/build/azure-templates/jobs-build-be.yml
+++ b/build/azure-templates/jobs-build-be.yml
@@ -23,7 +23,7 @@ jobs:
           runtime: "full"
           additionalArguments: "/updateassemblyinfo"
           useConfigFile: true
-          configFilePath: 'GitVersion.yml'
+          configFilePath: 'be/GitVersion.yml'
 
       # Install NuGet Tools
       - task: NuGetToolInstaller@1

--- a/build/azure-templates/jobs-build-be.yml
+++ b/build/azure-templates/jobs-build-be.yml
@@ -13,10 +13,17 @@ jobs:
       artifactName: "solution-webroot.zip"
 
     steps:
-      - task: GitVersion@5
+      - task: gitversion/setup@0
+        displayName: 'Install GitVersion'
+        inputs:
+          versionSpec: '5.8'
+      - task: gitversion/execute@0
+        displayName: 'Execute GitVersion'
         inputs:
           runtime: "full"
           additionalArguments: "/updateassemblyinfo"
+          useConfigFile: true
+          configFilePath: 'GitVersion.yml'
 
       # Install NuGet Tools
       - task: NuGetToolInstaller@1


### PR DESCRIPTION
-  new property `RedirectSearchData.SourceTermOriginal` added to preserve a url with original casing
-  `RedirectSearchData.SourceTermOriginal` used in `RedirectionService.GetAdditionalTargetUrlData` and `Regex.Match` with `RegexOptions.IgnoreCase` used so capture groups added to the redirect url have the original casing

Example:
As a result of this PR for the term `^test-redirect(.*)` and target `/test-target` the url:
[/test-redirect?query=AaZz123](/test-redirect?query=AaZz123)
now redirects to:
[/test-target?query=**A**a**Z**z123](/test-target?query=**A**a**Z**z123)
instead of:
[/test-target?query=**a**a**z**z123](/test-target?query=**a**a**z**z123)