### PR TITLE
Check if source term value is not null

### DIFF
--- a/be/src/Unic.UrlMapper2/code/Properties/AssemblyInfo.cs
+++ b/be/src/Unic.UrlMapper2/code/Properties/AssemblyInfo.cs
@@ -30,5 +30,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.3.0.0")]
-[assembly: AssemblyFileVersion("1.3.0.0")]
+[assembly: AssemblyVersion("1.3.1.0")]
+[assembly: AssemblyFileVersion("1.3.1.0")]

--- a/be/src/Unic.UrlMapper2/code/Services/RedirectSearcher.cs
+++ b/be/src/Unic.UrlMapper2/code/Services/RedirectSearcher.cs
@@ -83,7 +83,8 @@
             if (!redirect.PreserveQueryString) return;
 
             redirect.RegexEnabled = true;
-            if (!redirectSearchResultItem.SourceTerm.EndsWith(Constants.RegularExpressions.QueryStringExpression))
+            if (!string.IsNullOrWhiteSpace(redirectSearchResultItem.SourceTerm) 
+                && !redirectSearchResultItem.SourceTerm.EndsWith(Constants.RegularExpressions.QueryStringExpression))
             {
                 redirect.Term = redirectSearchResultItem.SourceTerm + Constants.RegularExpressions.QueryStringExpression;
             }

--- a/be/src/Unic.UrlMapper2/code/Services/RedirectSearcher.cs
+++ b/be/src/Unic.UrlMapper2/code/Services/RedirectSearcher.cs
@@ -83,8 +83,9 @@
             if (!redirect.PreserveQueryString) return;
 
             redirect.RegexEnabled = true;
-            if (!string.IsNullOrWhiteSpace(redirectSearchResultItem.SourceTerm) 
-                && !redirectSearchResultItem.SourceTerm.EndsWith(Constants.RegularExpressions.QueryStringExpression))
+            var sourceTerm = redirectSearchResultItem.SourceTerm;
+            if (!string.IsNullOrWhiteSpace(sourceTerm) 
+                && !sourceTerm.EndsWith(Constants.RegularExpressions.QueryStringExpression))
             {
                 redirect.Term = redirectSearchResultItem.SourceTerm + Constants.RegularExpressions.QueryStringExpression;
             }

--- a/be/src/Unic.UrlMapper2/code/Services/RedirectSearcher.cs
+++ b/be/src/Unic.UrlMapper2/code/Services/RedirectSearcher.cs
@@ -63,6 +63,7 @@
                 this.logger.Error($"Failed to parse source protocol {redirectSearchResultItem.SourceProtocol}", this);
             }
 
+            var sourceTerm = redirectSearchResultItem.SourceTerm;
             var redirect = new Redirect
             {
                 RedirectSearchData = redirectSearchData,
@@ -71,23 +72,22 @@
                 SourceProtocol = sourceProtocol,
                 RegexEnabled = redirectSearchResultItem.RegexEnabled,
                 PreserveQueryString = redirectSearchResultItem.PreserveQueryString,
-                Term = redirectSearchResultItem.SourceTerm
+                Term = sourceTerm
             };
 
-            this.HandlePreserveQueryString(redirect, redirectSearchResultItem);
+            this.HandlePreserveQueryString(redirect, sourceTerm);
             return redirect;
         }
 
-        protected virtual void HandlePreserveQueryString(Redirect redirect, RedirectSearchResultItem redirectSearchResultItem)
+        protected virtual void HandlePreserveQueryString(Redirect redirect, string sourceTerm)
         {
             if (!redirect.PreserveQueryString) return;
 
             redirect.RegexEnabled = true;
-            var sourceTerm = redirectSearchResultItem.SourceTerm;
             if (!string.IsNullOrWhiteSpace(sourceTerm) 
                 && !sourceTerm.EndsWith(Constants.RegularExpressions.QueryStringExpression))
             {
-                redirect.Term = redirectSearchResultItem.SourceTerm + Constants.RegularExpressions.QueryStringExpression;
+                redirect.Term = sourceTerm + Constants.RegularExpressions.QueryStringExpression;
             }
         }
 

--- a/be/src/Unic.UrlMapper2/code/Services/RedirectionService.cs
+++ b/be/src/Unic.UrlMapper2/code/Services/RedirectionService.cs
@@ -102,8 +102,8 @@
             if (string.IsNullOrWhiteSpace(sourceTerm)) return default;
 
             // We are going to take the one regex redirect which has the longest match within the term
-            var regexMatches = enumerableRedirects.Where(r => r.RegexEnabled && Regex.IsMatch(input: sourceTerm, pattern: r.Term));
-            var regexMatch = regexMatches.OrderByDescending(r => r.Term.Length).FirstOrDefault();
+            var regexMatches = enumerableRedirects.Where(r => r.RegexEnabled && !string.IsNullOrWhiteSpace(r.Term) && Regex.IsMatch(input: sourceTerm, pattern: r.Term));
+            var regexMatch = regexMatches.OrderByDescending(r => r.Term?.Length).FirstOrDefault();
 
             return regexMatch;
         }


### PR DESCRIPTION
Bug fix in case when author forgets to fill in the "Source Term" field in Redirect item. 