### PR TITLE
Feature/fix preserve query string for no regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ Capture groups can be defined when the regex feature has been enabled for a redi
 
 The following term definition matches incoming terms for `global-capture` and transfers all query strings to the target (if any have been provided): `^global-capture([?].*)?`
 
+### Preserve Query String
+
+When this checkbox is checked, the query string from the original request will be passed on to the redirect location. When `Regex enabled` is unchecked, the request url path (excluding the query) has to be an exact match for the `Source term`. If `Source Term` contains a query, then the request url's query string has to start with the query from the `Source Term`.
+
+For example, when `Preserve Query String` is checked, `Regex enabled` is unchecked, and `Source Term` is set to `test`, then this request: `https://mysite.com/test?a=b` will be redirected to the target with the query string included.
+If the `Source Term` would be `test?a=b` then this request: `https://mysite.com/test?a=b&c=d` will be a match and redirected to the target with the whole query string included, but this request: `https://mysite.com/test?c=d&a=b` will not be a match.
+
 ### Bulk Import
 
 A Sitecore PowerShell script is included allowing Authors to upload a CSV containing redirect definitions.

--- a/be/src/Unic.UrlMapper2/code/Definitions/Constants.cs
+++ b/be/src/Unic.UrlMapper2/code/Definitions/Constants.cs
@@ -58,7 +58,8 @@
 
         public struct RegularExpressions
         {
-            public const string QueryStringExpression = "([?].*)?";
+            public const string QueryStringPattern = "([?].*)?";
+            public const string PartialQueryStringPattern = "([&].*)?";
         }
     }
 }

--- a/be/src/Unic.UrlMapper2/code/Properties/AssemblyInfo.cs
+++ b/be/src/Unic.UrlMapper2/code/Properties/AssemblyInfo.cs
@@ -30,5 +30,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.3.1.0")]
-[assembly: AssemblyFileVersion("1.3.1.0")]
+[assembly: AssemblyVersion("1.3.2.0")]
+[assembly: AssemblyFileVersion("1.3.2.0")]

--- a/be/src/Unic.UrlMapper2/code/Services/RedirectSearcher.cs
+++ b/be/src/Unic.UrlMapper2/code/Services/RedirectSearcher.cs
@@ -96,7 +96,7 @@
             redirect.RegexEnabled = true;
             if (!sourceTerm.Contains("?"))
             {
-                redirect.Term = $"{sourceTerm}{Constants.RegularExpressions.QueryStringPattern}$";
+                redirect.Term = $"^{sourceTerm}{Constants.RegularExpressions.QueryStringPattern}$";
                 return;
             }
 
@@ -104,7 +104,7 @@
             var addSourceTermQuery = !sourceTerm.EndsWith("?");
             var sourceTermQuery = addSourceTermQuery ? sourceTerm.Substring(sourceTerm.IndexOf("?", StringComparison.InvariantCultureIgnoreCase) + 1) : string.Empty;
 
-            redirect.Term = $"{sourceTermPath}{(addSourceTermQuery ? $"([?]{sourceTermQuery}{Constants.RegularExpressions.PartialQueryStringPattern})" : Constants.RegularExpressions.QueryStringPattern)}$";
+            redirect.Term = $"^{sourceTermPath}{(addSourceTermQuery ? $"([?]{sourceTermQuery}{Constants.RegularExpressions.PartialQueryStringPattern})" : Constants.RegularExpressions.QueryStringPattern)}$";
         }
 
         protected virtual IQueryable<RedirectSearchResultItem> GetSearchQuery(IProviderSearchContext searchContext, RedirectSearchData redirectSearchData)

--- a/be/src/Unic.UrlMapper2/code/Services/RedirectSearcher.cs
+++ b/be/src/Unic.UrlMapper2/code/Services/RedirectSearcher.cs
@@ -81,14 +81,30 @@
 
         protected virtual void HandlePreserveQueryString(Redirect redirect, string sourceTerm)
         {
-            if (!redirect.PreserveQueryString) return;
-
-            redirect.RegexEnabled = true;
-            if (!string.IsNullOrWhiteSpace(sourceTerm) 
-                && !sourceTerm.EndsWith(Constants.RegularExpressions.QueryStringExpression))
+            if (!redirect.PreserveQueryString || string.IsNullOrWhiteSpace(sourceTerm)) return;
+            if (redirect.RegexEnabled)
             {
-                redirect.Term = sourceTerm + Constants.RegularExpressions.QueryStringExpression;
+                if (!sourceTerm.EndsWith(Constants.RegularExpressions.QueryStringPattern))
+                {
+                    redirect.Term = sourceTerm + Constants.RegularExpressions.QueryStringPattern;
+                }
+
+                return;
             }
+
+            // if regex was not enabled we need to make sure that with Preserve Query string we match the exact source term and a query
+            redirect.RegexEnabled = true;
+            if (!sourceTerm.Contains("?"))
+            {
+                redirect.Term = $"{sourceTerm}{Constants.RegularExpressions.QueryStringPattern}$";
+                return;
+            }
+
+            var sourceTermPath = sourceTerm.Substring(0, sourceTerm.IndexOf("?", StringComparison.InvariantCultureIgnoreCase));
+            var addSourceTermQuery = !sourceTerm.EndsWith("?");
+            var sourceTermQuery = addSourceTermQuery ? sourceTerm.Substring(sourceTerm.IndexOf("?", StringComparison.InvariantCultureIgnoreCase) + 1) : string.Empty;
+
+            redirect.Term = $"{sourceTermPath}{(addSourceTermQuery ? $"([?]{sourceTermQuery}{Constants.RegularExpressions.PartialQueryStringPattern})" : Constants.RegularExpressions.QueryStringPattern)}$";
         }
 
         protected virtual IQueryable<RedirectSearchResultItem> GetSearchQuery(IProviderSearchContext searchContext, RedirectSearchData redirectSearchData)


### PR DESCRIPTION
###Previous state:
When `Preserve Query String` was checked and `Regex enabled` unchecked, then this would happen:
- we take `Source Term`
- we enable regex on the Redirect object
- we add query string regex

Then we try to match and we copy the query string to target.
As a result, the match between url path and `Source Term` was not exact. E.g. with `Source Term` 'test', we're ending up with regex `test([?].*)?` which matches all urls containing 'test' substring

At the same time, we want to use the regex to match the query string and copy it, due to previously existing mechanisms (see https://github.com/unic/SitecoreUrlMapper2/blob/main/be/src/Unic.UrlMapper2/code/Services/RedirectionService.cs#L59)

###The change
In the case when `Preserve Query String` was checked and `Regex enabled` unchecked we:
- take the `Source Term` and do this:
  - if `Source Term` has no query, we end up with regex ^{SourceTerm}([?].*)?$  
  - if `SourceTerm` ends with '?', we end up with regex ^{SourceTerm without last character}([?].*)?$
  - if `SourceTerm` is Path and Query, we end up with regex ^{Path}([?]{Query}([&].*)?)$ -> to match only urls starting with `SourceTerm` and to copy the whole query string to the target


This covers (but is not limited to) following usecases:

Source Term | Preserve Query String | Regex | Url | Matched | Redirect location
-- | -- | -- | -- | -- | --
abc |   |   | abc?a=b |   | n/a
def | x |   | def?a=b | x | /en/main-area?a=b
ghi?a=b |   |   | ghi?a=b | x | /en/main-area
jkl?a=b | x |   | jkl?a=b | x | /en/main-area?a=b
xyz |   | x | xyz?a=b | x | /en/main-area
uvw | x | x | uvw?a=b | x | /en/main-area?a=b
rst([?].*)? |   | x | rst?a=b | x | /en/main-area?a=b
opq([?].*)? | x | x | opq?a=b | x | /en/main-area?a=b

