### PR TITLE
Feature/check empty source

### DIFF
--- a/be/src/Unic.UrlMapper2/code/Properties/AssemblyInfo.cs
+++ b/be/src/Unic.UrlMapper2/code/Properties/AssemblyInfo.cs
@@ -30,5 +30,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.3.2.0")]
-[assembly: AssemblyFileVersion("1.3.2.0")]
+[assembly: AssemblyVersion("1.3.3.0")]
+[assembly: AssemblyFileVersion("1.3.3.0")]

--- a/be/src/Unic.UrlMapper2/code/Services/RedirectSearcher.cs
+++ b/be/src/Unic.UrlMapper2/code/Services/RedirectSearcher.cs
@@ -39,7 +39,7 @@
             using (var searchContext = ContentSearchManager.GetIndex(indexName).CreateSearchContext())
             {
                 var queryable = this.GetSearchQuery(searchContext, redirectSearchData);
-                results = queryable.ToList().DistinctBy(r => r.ItemId)?.ToList();
+                results = queryable.ToList().Where(r => !string.IsNullOrWhiteSpace(r.SourceTerm) && !string.IsNullOrWhiteSpace(r.TargetUrl)).DistinctBy(r => r.ItemId)?.ToList();
             }
 
             if (results != null && results.Any())

--- a/be/src/Unic.UrlMapper2/serialization/Templates/UrlMapper2/Redirect/Redirect Configuration/Source Term.yml
+++ b/be/src/Unic.UrlMapper2/serialization/Templates/UrlMapper2/Redirect/Redirect Configuration/Source Term.yml
@@ -5,6 +5,22 @@ Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
 Path: /sitecore/templates/Modules/UrlMapper2/Redirect/Redirect Configuration/Source Term
 DB: master
 SharedFields:
+- ID: "21828437-ea4b-40a1-8c61-4ce60ea41db6"
+  Hint: Validate Button
+  Type: tree list
+  Value: "{59D4EE10-627C-4FD3-A964-61A88B092CBC}"
+- ID: "337e20e1-999a-4eea-85ad-b58a03ae75cc"
+  Hint: Quick Action Bar
+  Type: tree list
+  Value: "{59D4EE10-627C-4FD3-A964-61A88B092CBC}"
+- ID: "53c432c4-7122-4e2d-8296-db4184fd1735"
+  Hint: Workflow
+  Type: tree list
+  Value: "{59D4EE10-627C-4FD3-A964-61A88B092CBC}"
+- ID: "9c903e29-650d-4af2-b9bd-526d5c14a1a5"
+  Hint: Validator Bar
+  Type: tree list
+  Value: "{59D4EE10-627C-4FD3-A964-61A88B092CBC}"
 - ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
   Hint: Type
   Value: "Single-Line Text"

--- a/be/src/Unic.UrlMapper2/serialization/Templates/UrlMapper2/Redirect/Redirect Configuration/Target.yml
+++ b/be/src/Unic.UrlMapper2/serialization/Templates/UrlMapper2/Redirect/Redirect Configuration/Target.yml
@@ -5,6 +5,22 @@ Template: "455a3e98-a627-4b40-8035-e683a0331ac7"
 Path: /sitecore/templates/Modules/UrlMapper2/Redirect/Redirect Configuration/Target
 DB: master
 SharedFields:
+- ID: "21828437-ea4b-40a1-8c61-4ce60ea41db6"
+  Hint: Validate Button
+  Type: tree list
+  Value: "{59D4EE10-627C-4FD3-A964-61A88B092CBC}"
+- ID: "337e20e1-999a-4eea-85ad-b58a03ae75cc"
+  Hint: Quick Action Bar
+  Type: tree list
+  Value: "{59D4EE10-627C-4FD3-A964-61A88B092CBC}"
+- ID: "53c432c4-7122-4e2d-8296-db4184fd1735"
+  Hint: Workflow
+  Type: tree list
+  Value: "{59D4EE10-627C-4FD3-A964-61A88B092CBC}"
+- ID: "9c903e29-650d-4af2-b9bd-526d5c14a1a5"
+  Hint: Validator Bar
+  Type: tree list
+  Value: "{59D4EE10-627C-4FD3-A964-61A88B092CBC}"
 - ID: "ab162cc0-dc80-4abf-8871-998ee5d7ba32"
   Hint: Type
   Value: General Link


### PR DESCRIPTION
### What changed?
 - added a check whether `Source Term` or `Target` are not null. Content search queries allow only simple comparisons, so the check had to be added after results are already enumerated
 - made fields `Source Term` and `Target` required in Sitecore, to indicate to authors that Redirect items without these fields are invalid