### PR TITLE
feat: ensure that fields are identified by ID not name

### DIFF
--- a/be/src/Unic.UrlMapper2/code/ContentSearch/ComputedFields/PreserveQueryStringComputedField.cs
+++ b/be/src/Unic.UrlMapper2/code/ContentSearch/ComputedFields/PreserveQueryStringComputedField.cs
@@ -9,7 +9,7 @@
     {
         protected override object Compute(IIndexable indexable)
         {
-            var value = indexable?.GetFieldByName(Constants.Fields.Redirect.PreserveQueryString)?.Value;
+            var value = indexable?.GetFieldById(Constants.Fields.Redirect.PreserveQueryString)?.Value;
             
             return MainUtil.GetBool(value, false);
         }

--- a/be/src/Unic.UrlMapper2/code/ContentSearch/ComputedFields/RedirectTypeComputedField.cs
+++ b/be/src/Unic.UrlMapper2/code/ContentSearch/ComputedFields/RedirectTypeComputedField.cs
@@ -15,7 +15,7 @@
         {
             var item = (Item)(indexable as SitecoreIndexableItem);
 
-            var value = indexable?.GetFieldByName(Constants.Fields.Redirect.RedirectType)?.Value;
+            var value = indexable?.GetFieldById(Constants.Fields.Redirect.RedirectType)?.Value;
             if (ID.TryParse(value, out var specificationId))
             {
                 return this.ResolveDependency<ISpecificationService>().GetSharedSpecification(item.Database, specificationId);

--- a/be/src/Unic.UrlMapper2/code/ContentSearch/ComputedFields/RegexEnabledComputedField.cs
+++ b/be/src/Unic.UrlMapper2/code/ContentSearch/ComputedFields/RegexEnabledComputedField.cs
@@ -9,7 +9,7 @@
     {
         protected override object Compute(IIndexable indexable)
         {
-            var value = indexable?.GetFieldByName(Constants.Fields.Redirect.RegexEnabled)?.Value;
+            var value = indexable?.GetFieldById(Constants.Fields.Redirect.RegexEnabled)?.Value;
             return MainUtil.GetBool(value, false);
         }
     }

--- a/be/src/Unic.UrlMapper2/code/ContentSearch/ComputedFields/SourceProtocolComputedField.cs
+++ b/be/src/Unic.UrlMapper2/code/ContentSearch/ComputedFields/SourceProtocolComputedField.cs
@@ -15,7 +15,7 @@
         {
             var item = (Item)(indexable as SitecoreIndexableItem);
 
-            var value = indexable?.GetFieldByName(Constants.Fields.Redirect.SourceProtocol)?.Value;
+            var value = indexable?.GetFieldById(Constants.Fields.Redirect.SourceProtocol)?.Value;
             if (ID.TryParse(value, out var specificationId))
             {
                 var protocol = this.ResolveDependency<ISpecificationService>().GetSharedSpecification(item.Database, specificationId);

--- a/be/src/Unic.UrlMapper2/code/ContentSearch/ComputedFields/SourceTermComputedField.cs
+++ b/be/src/Unic.UrlMapper2/code/ContentSearch/ComputedFields/SourceTermComputedField.cs
@@ -10,7 +10,7 @@
     {
         protected override object Compute(IIndexable indexable)
         {
-            var value = indexable?.GetFieldByName(Constants.Fields.Redirect.SourceTerm)?.Value as string;
+            var value = indexable?.GetFieldById(Constants.Fields.Redirect.SourceTerm)?.Value as string;
 
             return string.IsNullOrWhiteSpace(value)
                 ? default

--- a/be/src/Unic.UrlMapper2/code/ContentSearch/ComputedFields/TargetUrlComputedField.cs
+++ b/be/src/Unic.UrlMapper2/code/ContentSearch/ComputedFields/TargetUrlComputedField.cs
@@ -7,6 +7,6 @@
     [UsedImplicitly]
     public class TargetUrlComputedField : UrlMapperComputedFieldBase
     {
-        protected override object Compute(IIndexable indexable) => indexable?.GetFieldByName(Constants.Fields.Redirect.Target)?.Value;
+        protected override object Compute(IIndexable indexable) => indexable?.GetFieldById(Constants.Fields.Redirect.Target)?.Value;
     }
 }

--- a/be/src/Unic.UrlMapper2/code/Definitions/Constants.cs
+++ b/be/src/Unic.UrlMapper2/code/Definitions/Constants.cs
@@ -15,17 +15,17 @@
         {
             public struct Redirect
             {
-                public const string SourceTerm = "Source Term";
+                public static readonly ID SourceTerm = ID.Parse("{BF458D1E-59C8-4661-9AD0-67A95CB85785}");
 
-                public const string Target = "Target";
+                public static readonly ID Target = ID.Parse("{B64E1624-9590-4CAD-B3B6-802F4C794086}");
 
-                public const string RedirectType = "Redirect Type";
+                public static readonly ID RedirectType = ID.Parse("{BB67D28D-EFF1-4A65-BD01-DE64AC6E9DA4}");
 
-                public const string SourceProtocol = "Source Protocol";
+                public static readonly ID SourceProtocol = ID.Parse("{E453D759-43E3-4033-ADA8-245DDB56980D}");
 
-                public const string RegexEnabled = "Regex enabled";
+                public static readonly ID RegexEnabled = ID.Parse("{A21DADDF-E5B1-4134-B236-9515D9153EF6}");
 
-                public const string PreserveQueryString = "Preserve Query String";
+                public static readonly ID PreserveQueryString = ID.Parse("{A9D3D444-C009-4C90-B1A2-F8C25D28D084}");
             }
 
             public struct Specification

--- a/be/src/Unic.UrlMapper2/code/Properties/AssemblyInfo.cs
+++ b/be/src/Unic.UrlMapper2/code/Properties/AssemblyInfo.cs
@@ -30,5 +30,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.3.3.0")]
-[assembly: AssemblyFileVersion("1.3.3.0")]
+[assembly: AssemblyVersion("1.3.4.0")]
+[assembly: AssemblyFileVersion("1.3.4.0")]

--- a/build/sif-configs/Prerequisites.json
+++ b/build/sif-configs/Prerequisites.json
@@ -24,7 +24,7 @@
         "WebPlatformDownload": {
             "Type": "String",
             "Description": "Download location of Microsoft Web Platform Installer 5.0",
-            "DefaultValue": "https://download.microsoft.com/download/C/F/F/CFF3A0B8-99D4-41A2-AE1A-496C08BEB904/WebPlatformInstaller_amd64_en-US.msi"
+            "DefaultValue": "https://download.microsoft.com/download/8/4/9/849DBCF2-DFD9-49F5-9A19-9AEE5B29341A/WebPlatformInstaller_x64_en-US.msi"
         },
         "SQLClrTypesx86Download": {
             "Type": "String",


### PR DESCRIPTION
Changed the way item fields are accessed: from accessing them by name to accessing them by ID.

Reason:
- IDs are more reliable than names
- access by name may pose an issue when module templates are installed with items as resources mechanism