### PR TITLE
feat: add a possibility to specify no-cache and no-store Cache-Contro…

### DIFF
--- a/be/src/Unic.UrlMapper2/code/App_Config/Include/UrlMapper2/UrlMapper2.Settings.config
+++ b/be/src/Unic.UrlMapper2/code/App_Config/Include/UrlMapper2/UrlMapper2.Settings.config
@@ -13,6 +13,9 @@
 
       <setting name="UrlMapper2.UseOriginalUrlHeaderForJssProcessor" set:value="false" />
       <setting name="UrlMapper2.OriginalUrlHeaderForJssProcessor" set:value="set-me" />
+
+      <setting name="UrlMapper2.CacheControl.SetNoCache" set:value="false" />
+      <setting name="UrlMapper2.CacheControl.SetNoStore" set:value="false" />
     </settings>
   </sitecore>
 </configuration>

--- a/be/src/Unic.UrlMapper2/code/Definitions/Constants.cs
+++ b/be/src/Unic.UrlMapper2/code/Definitions/Constants.cs
@@ -54,6 +54,10 @@
             public const string UseOriginalUrlHeaderForJssProcessor = "UrlMapper2.UseOriginalUrlHeaderForJssProcessor";
 
             public const string OriginalUrlHeaderForJssProcessor = "UrlMapper2.OriginalUrlHeaderForJssProcessor";
+
+            public const string CacheControlHeaderSetNoCache = "UrlMapper2.CacheControl.SetNoCache";
+
+            public const string CacheControlHeaderSetNoStore = "UrlMapper2.CacheControl.SetNoStore";
         }
 
         public struct RegularExpressions

--- a/be/src/Unic.UrlMapper2/code/Properties/AssemblyInfo.cs
+++ b/be/src/Unic.UrlMapper2/code/Properties/AssemblyInfo.cs
@@ -30,5 +30,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.3.4.0")]
-[assembly: AssemblyFileVersion("1.3.4.0")]
+[assembly: AssemblyVersion("1.4.0")]
+[assembly: AssemblyFileVersion("1.4.0")]

--- a/be/src/Unic.UrlMapper2/code/Services/RedirectionService.cs
+++ b/be/src/Unic.UrlMapper2/code/Services/RedirectionService.cs
@@ -20,6 +20,7 @@
         private readonly IUrlMapperContext context;
         private readonly BaseLinkManager linkManager;
         private readonly BaseMediaManager mediaManager;
+        private readonly BaseSettings baseSettings;
 
         public RedirectionService(
             IRedirectSearcher redirectSearcher,
@@ -27,7 +28,8 @@
             BaseLog logger,
             IUrlMapperContext context,
             BaseLinkManager linkManager,
-            BaseMediaManager mediaManager)
+            BaseMediaManager mediaManager,
+            BaseSettings baseSettings)
         {
             this.redirectSearcher = redirectSearcher;
             this.sanitizer = sanitizer;
@@ -35,6 +37,7 @@
             this.context = context;
             this.linkManager = linkManager;
             this.mediaManager = mediaManager;
+            this.baseSettings = baseSettings;
         }
 
         public virtual void PerformRedirect(RedirectSearchData redirectSearchData, HttpContextBase httpContext)
@@ -130,6 +133,18 @@
                 return;
             }
 
+            var setNoCache = this.baseSettings.GetBoolSetting(Constants.Settings.CacheControlHeaderSetNoCache, false);
+            var setNoStore = this.baseSettings.GetBoolSetting(Constants.Settings.CacheControlHeaderSetNoStore, false);
+            if (setNoCache)
+            {
+                httpContext.Response.Cache.SetCacheability(HttpCacheability.NoCache);
+            }
+
+            if (setNoStore)
+            {
+                httpContext.Response.Cache.SetNoStore();
+            }
+           
             this.logger.Debug($"Performing {redirect.RedirectType} redirect to {targetUrl}", this);
 
             switch (redirect.RedirectType)

--- a/be/src/Unic.UrlMapper2/serialization/Script Library/UrlMapper2/Development/Generate-DistributionPackage.yml
+++ b/be/src/Unic.UrlMapper2/serialization/Script Library/UrlMapper2/Development/Generate-DistributionPackage.yml
@@ -11,12 +11,12 @@ SharedFields:
     # Inspired by https://github.com/SitecorePowerShell/Console/blob/b751ee62351290b955d750c7c71aed6b210d788b/Spe/Data/Unicorn/SPE/Scripts/SPE/SPE/Core/Platform/Development/PowerShell%20Extensions%20Maintena/Prepare%20Console%20Distribution.yml
     
     #TODO during release process: Update the $version variable
-    $version = "1.0"
+    $version = "1.4.0"
         
     $package = New-Package "UrlMapper2"
     $package.Sources.Clear()
     
-    $package.Metadata.Author = "David Szöke, Tobias Studer, Christian Hahnloser"
+    $package.Metadata.Author = "Unic AG"
     $package.Metadata.Publisher = "Unic AG"
     $package.Metadata.Version = $version
     


### PR DESCRIPTION
Added a possibility to specifically set `no-cache` or `no-store` as `Cache-Control` header for redirects. Otherwise it sets the default ASP.NET value of `private`.

- added two new config settings
  - backwards compatibility - if they're not there, or set to default value, everything works as it did up until now
- if any of the new settings is set to true, a respective value of `Cache-Control` header is applied